### PR TITLE
Hotfix 1.0.2: Revert to an old way of connecting the exact player version dependency

### DIFF
--- a/Package.resolved
+++ b/Package.resolved
@@ -6,17 +6,17 @@
         "repositoryURL": "https://github.com/bitmovin/bitmovin-analytics-collector-ios.git",
         "state": {
           "branch": null,
-          "revision": "3431fdbfb3098c0826b332ec52c869a30f20b947",
-          "version": "3.6.2"
+          "revision": "3feebb1db5f6bc2d3ad0b7241f3baea523e9ab9e",
+          "version": "3.6.0"
         }
       },
       {
         "package": "BitmovinPlayer",
         "repositoryURL": "https://github.com/bitmovin/player-ios.git",
         "state": {
-          "branch": "3.56.1",
+          "branch": null,
           "revision": "31ed8a5fb931bd600c5e1ca6d19c17d77762b56b",
-          "version": null
+          "version": "3.56.1"
         }
       },
       {

--- a/Package.swift
+++ b/Package.swift
@@ -20,8 +20,11 @@ let package = Package(
         // Declare dependencies
         
         // BitmovinPlayer
-        .package(url: "https://github.com/bitmovin/player-ios.git",
-                 revision: "3.56.1"),
+        .package(
+            name: "BitmovinPlayer",
+            url: "https://github.com/bitmovin/player-ios.git",
+            .exact("3.56.1")
+        ),
 
         // other dependencies
         .package(url: "https://github.com/apple/swift-docc-plugin", from: "1.0.0")
@@ -33,7 +36,7 @@ let package = Package(
         .target(
             name: "PlaybackSDK",
             dependencies: [
-                .product(name: "BitmovinPlayer", package: "player-ios"),
+                .product(name: "BitmovinPlayer", package: "BitmovinPlayer"),
             ]
         ),
         .testTarget(


### PR DESCRIPTION
## Jira
- related to https://pa-media-group.atlassian.net/browse/ZEUS-4356
## Changes
We are getting a deprecation warning in Package.swift, so in the previous PR I tried switching the dependency to a new "revision" way of connecting the player dependency. This worked fine when connecting the package locally.   
However, when pulling in another project, it resulted in an error while trying to pull the correct player version. That's why for now I'm reverting this part to the way it was working before, at least until we decide to update the version of Bitmovin player.  